### PR TITLE
Support TXT record splitting

### DIFF
--- a/tdns/contents.cc
+++ b/tdns/contents.cc
@@ -40,6 +40,8 @@ void loadZones(DNSNode& zones)
   newzone->add({"ent", "was", "here"})->addRRs(TXTGen::make("plenum"));
   newzone->add({"some.embedded.dots"})->addRRs(TXTGen::make("what do the dots look like?"));
 
+  newzone->add({"split"})->addRRs(TXTGen::make("hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello"));
+  newzone->add({"split"})->addRRs(TXTGen::make({{"this is the first part"},{"this is the second part"}}));
 
   const char zero[]="name-does-not-stop-here\x0-it-goes-on";
   std::string zstring(zero, sizeof(zero)-1);

--- a/tdns/record-types.cc
+++ b/tdns/record-types.cc
@@ -53,9 +53,14 @@ void MXGen::toMessage(DNSMessageWriter& dmw)
 
 void TXTGen::toMessage(DNSMessageWriter& dmw) 
 {
-  // XXX should autosplit
-  dmw.putUInt8(d_txt.length());
-  dmw.putBlob(d_txt);
+  for(auto segment: d_txts) {
+    while(segment.length() > 0) {
+      const auto fragment = segment.substr(0, 254);
+      dmw.putUInt8(fragment.length());
+      dmw.putBlob(fragment);
+      segment.erase(0, fragment.length());
+    }
+  }
 }
 
 void ClockTXTGen::toMessage(DNSMessageWriter& dmw) 

--- a/tdns/record-types.hh
+++ b/tdns/record-types.hh
@@ -90,14 +90,22 @@ struct MXGen : RRGen
 
 struct TXTGen : RRGen
 {
-  TXTGen(const std::string& txt) : d_txt(txt) {}
+  TXTGen(const std::vector<std::string>& txts) : d_txts(txts) {}
+  TXTGen(const std::string& txt) : d_txts({txt}) {}
+
+  static std::unique_ptr<RRGen> make(const std::vector<std::string>& txts)
+  {
+    return std::make_unique<TXTGen>(txts);
+  }
+
   static std::unique_ptr<RRGen> make(const std::string& txt)
   {
     return std::make_unique<TXTGen>(txt);
   }
+
   void toMessage(DNSMessageWriter& dpw) override;
   DNSType getType() const override { return DNSType::TXT; }
-  std::string d_txt;
+  std::vector<std::string> d_txts;
 };
 
 struct ClockTXTGen : RRGen


### PR DESCRIPTION
Adds support for manual and automatic splitting

If the string starts with `"`, expect that there is one or more `"` separated records.

If it does not, split it automatically on every 254 bytes.