### PR TITLE
For SOA, say "has" rather than "starts with"

### DIFF
--- a/basic.md
+++ b/basic.md
@@ -410,7 +410,7 @@ $origin www.ietf.org
 
 
 ### Start of Authority
-A zone always starts with a SOA or Start Of Authority record.  A SOA record
+A zone always has a SOA or Start Of Authority record.  A SOA record
 is DNS metadata.  It stores various things that may be of interest about a
 zone, like the email address of the maintainer, the name of the most
 authoritative server.  It also has values that describe how or if a zone


### PR DESCRIPTION
Since the doc is talking about zones in the abstract (not zone files),
I found it a bit confusing to read "starts with." As I understand it, there's
no notion of ordering to zones in the general sense. Is that right?

I think saying "has" instead resolves the confusion.