### PR TITLE
Update CNAME section for accuracy

### DIFF
--- a/resolver.md
+++ b/resolver.md
@@ -78,13 +78,14 @@ Once we have an IP address for a `powerdns.org` nameserver, we can ask it
 about `www.powerdns.org`.
 
 ## CNAMEs
-CNAMEs complicate this process slightly but not fundamentally. A CNAME
-redirects our query to a new name. This means that once a CNAME is hit, the
-initial algorithm terminates, and gets restarted for the new CNAME target.
+CNAME records complicate this process slightly but not fundamentally. A 
+CNAME record redirects our query to a new name. This means that once a 
+CNAME record is hit, the initial algorithm terminates, and gets restarted 
+for the new Canonical Name (CNAME) target.
 
-Frequently, a CNAME points to a name that is also within the same zone, for
-example `www.powerdns.org. IN CNAME powerdns.org`. Authoritative servers
-then typically also include the requested type for `powerdns.org` in the
+Frequently, a CNAME record points to a canonical name that is also within the 
+same zone, for example `www.powerdns.org. IN CNAME powerdns.org`. Authoritative 
+servers then typically also include the requested type for `powerdns.org` in the
 same DNS response. As an optimization, a resolver can use this CNAME record
 and terminate the algorithm.
 


### PR DESCRIPTION
I was browsing through some documentation when I came across this free resource with information for the public, and while browsing this I realized that there was a flaw in one of the pages. Once I cleared my eyes, I confirmed that, yes, somebody was WRONG on the INTERNET! Now, as I am unable to disclose which benevolent mega-corporation I am working for where this is relevant, I have had to take this upon myself to anonymously correct this mistake! A fact that is blatantly obvious to the most casual observer! 

A CNAME (short for Canonical NAME) record points to the Canonical ("True") Name of that record, therefore the CNAME record is not actually the CNAME but the only type of record that is not its own CNAME. 

As a group of people providing free resources to us strangers, you must understand the importance of providing further free labor to us on-demand. As such, I have taken the liberty to update these documents to correct this injustice. I hope this will be a learning experience for all involved. 


<details><summary>Context</summary>
<p>

This is a satirical PR meant as a tongue-in-cheek jab at @ahupowerdns's blog post https://berthub.eu/articles/posts/anonymous-help/. It seemed a little too excessive to go out of my way to make and verify a new github account for this, so I guess I broke the spell slightly. 

There is no megacorp who relies on these docs (at least, not one that I'm a part of). I take no offense if this gag-PR is closed. While the information in the changes is, to the best of my knowledge, real and accurate, it's also a *pedantic* level of correctness that isn't so useful in day-to-day DNS parlance.

Thanks @morrowc for tipping me off to this gag/sending me this way.

</p>
</details> 